### PR TITLE
Feature/prod 431 usuario define tarefa como ativa

### DIFF
--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/api/TarefaAPI.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/api/TarefaAPI.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,6 +25,11 @@ public interface TarefaAPI {
     @GetMapping("/{idTarefa}")
     @ResponseStatus(code = HttpStatus.OK)
     TarefaDetalhadoResponse detalhaTarefa(@RequestHeader(name = "Authorization",required = true) String token, 
+    		@PathVariable UUID idTarefa);
+    
+    @PatchMapping("ativa-tarefa/{idTarefa}")
+    @ResponseStatus(code = HttpStatus.NO_CONTENT)
+    void ativaTarefa(@RequestHeader(name = "Authorization",required = true) String token, 
     		@PathVariable UUID idTarefa);
 
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/api/TarefaRestController.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/api/TarefaRestController.java
@@ -42,4 +42,11 @@ public class TarefaRestController implements TarefaAPI {
 		return usuario;
 	}
 
+	@Override
+	public void ativaTarefa(String token, UUID idTarefa) {
+		log.info("[inicia] TarefaRestController - ativaTarefa");
+		tarefaService.ativaTarefa(token, idTarefa);
+		log.info("[finaliza] TarefaRestController - ativaTarefa");		
+	}
+
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/api/TarefaRestController.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/api/TarefaRestController.java
@@ -45,7 +45,8 @@ public class TarefaRestController implements TarefaAPI {
 	@Override
 	public void ativaTarefa(String token, UUID idTarefa) {
 		log.info("[inicia] TarefaRestController - ativaTarefa");
-		tarefaService.ativaTarefa(token, idTarefa);
+		String email = getUsuarioByToken(token);
+		tarefaService.ativaTarefa(email, idTarefa);
 		log.info("[finaliza] TarefaRestController - ativaTarefa");		
 	}
 

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/repository/TarefaRepository.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/repository/TarefaRepository.java
@@ -1,13 +1,12 @@
 package dev.wakandaacademy.produdoro.tarefa.application.repository;
 
-import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
-
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
 
 public interface TarefaRepository {
     Tarefa salva(Tarefa tarefa);
     Optional<Tarefa> buscaTarefaPorId(UUID idTarefa);
-    Optional<Tarefa> buscaTarefaAtiva();
+	void desativaTarefaAtiva(UUID idUsuario);
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/repository/TarefaRepository.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/repository/TarefaRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface TarefaRepository {
-
     Tarefa salva(Tarefa tarefa);
     Optional<Tarefa> buscaTarefaPorId(UUID idTarefa);
+    Optional<Tarefa> buscaTarefaAtiva();
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
@@ -12,6 +12,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -42,7 +43,18 @@ public class TarefaApplicationService implements TarefaService {
     }
 	@Override
 	public void ativaTarefa(String token, UUID idTarefa) {
-		// TODO Auto-generated method stub
-		
+		log.info("[inicia] TarefaApplicationService - ativaTarefa");
+		Tarefa tarefa = tarefaRepository.buscaTarefaPorId(idTarefa).orElseThrow(()-> APIException.build(HttpStatus.NOT_FOUND, "Id da tarefa invalido!"));
+		desativaTarefaAtiva();
+		tarefa.ativaTarefa();
+		tarefaRepository.salva(tarefa);
+		log.info("[finaliza] TarefaApplicationService - ativaTarefa");
+	}
+	public void desativaTarefaAtiva() {
+		Optional<Tarefa> tarefaAtiva = tarefaRepository.buscaTarefaAtiva();
+		tarefaAtiva.ifPresent(tarefaAtual -> {
+			tarefaAtual.desativaTarefa();
+			tarefaRepository.salva(tarefaAtual);
+		});
 	}
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
@@ -40,4 +40,9 @@ public class TarefaApplicationService implements TarefaService {
         log.info("[finaliza] TarefaApplicationService - detalhaTarefa");
         return tarefa;
     }
+	@Override
+	public void ativaTarefa(String token, UUID idTarefa) {
+		// TODO Auto-generated method stub
+		
+	}
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -42,19 +40,14 @@ public class TarefaApplicationService implements TarefaService {
         return tarefa;
     }
 	@Override
-	public void ativaTarefa(String token, UUID idTarefa) {
+	public void ativaTarefa(String email, UUID idTarefa) {
 		log.info("[inicia] TarefaApplicationService - ativaTarefa");
 		Tarefa tarefa = tarefaRepository.buscaTarefaPorId(idTarefa).orElseThrow(()-> APIException.build(HttpStatus.NOT_FOUND, "Id da tarefa invalido!"));
-		desativaTarefaAtiva();
+		Usuario usuario = usuarioRepository.buscaUsuarioPorEmail(email);
+		tarefa.pertenceAoUsuario(usuario);
+		tarefaRepository.desativaTarefaAtiva(usuario.getIdUsuario());
 		tarefa.ativaTarefa();
 		tarefaRepository.salva(tarefa);
 		log.info("[finaliza] TarefaApplicationService - ativaTarefa");
-	}
-	public void desativaTarefaAtiva() {
-		Optional<Tarefa> tarefaAtiva = tarefaRepository.buscaTarefaAtiva();
-		tarefaAtiva.ifPresent(tarefaAtual -> {
-			tarefaAtual.desativaTarefa();
-			tarefaRepository.salva(tarefaAtual);
-		});
 	}
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationService.java
@@ -45,6 +45,7 @@ public class TarefaApplicationService implements TarefaService {
 		Tarefa tarefa = tarefaRepository.buscaTarefaPorId(idTarefa).orElseThrow(()-> APIException.build(HttpStatus.NOT_FOUND, "Id da tarefa invalido!"));
 		Usuario usuario = usuarioRepository.buscaUsuarioPorEmail(email);
 		tarefa.pertenceAoUsuario(usuario);
+		tarefa.verificaSeJaEstaAtiva();
 		tarefaRepository.desativaTarefaAtiva(usuario.getIdUsuario());
 		tarefa.ativaTarefa();
 		tarefaRepository.salva(tarefa);

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaService.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaService.java
@@ -8,5 +8,5 @@ import java.util.UUID;
 public interface TarefaService {
     TarefaIdResponse criaNovaTarefa(TarefaRequest tarefaRequest);
     Tarefa detalhaTarefa(String usuario, UUID idTarefa);
-	void ativaTarefa(String token, UUID idTarefa);
+	void ativaTarefa(String email, UUID idTarefa);
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaService.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaService.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 public interface TarefaService {
     TarefaIdResponse criaNovaTarefa(TarefaRequest tarefaRequest);
     Tarefa detalhaTarefa(String usuario, UUID idTarefa);
+	void ativaTarefa(String token, UUID idTarefa);
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/domain/Tarefa.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/domain/Tarefa.java
@@ -63,4 +63,13 @@ public class Tarefa {
 	public void ativaTarefa() {
 		this.statusAtivacao = StatusAtivacaoTarefa.ATIVA;
 	}
+
+	public void verificaSeJaEstaAtiva() {
+		if(this.statusAtivacao.equals(StatusAtivacaoTarefa.ATIVA)){
+			throw APIException.build(HttpStatus.CONFLICT, "Tarefa já está ativa!");
+		}
+		
+	}
+
 }
+

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/domain/Tarefa.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/domain/Tarefa.java
@@ -55,4 +55,12 @@ public class Tarefa {
 			throw APIException.build(HttpStatus.UNAUTHORIZED, "Usuário não é dono da Tarefa solicitada!");
 		}
 	}
+
+	public void desativaTarefa() {
+		this.statusAtivacao = StatusAtivacaoTarefa.INATIVA;
+	}
+
+	public void ativaTarefa() {
+		this.statusAtivacao = StatusAtivacaoTarefa.ATIVA;
+	}
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaInfraRepository.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaInfraRepository.java
@@ -2,6 +2,7 @@ package dev.wakandaacademy.produdoro.tarefa.infra;
 
 import dev.wakandaacademy.produdoro.handler.APIException;
 import dev.wakandaacademy.produdoro.tarefa.application.repository.TarefaRepository;
+import dev.wakandaacademy.produdoro.tarefa.domain.StatusAtivacaoTarefa;
 import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -16,7 +17,6 @@ import java.util.UUID;
 @Log4j2
 @RequiredArgsConstructor
 public class TarefaInfraRepository implements TarefaRepository {
-
     private final TarefaSpringMongoDBRepository tarefaSpringMongoDBRepository;
 
     @Override
@@ -37,4 +37,11 @@ public class TarefaInfraRepository implements TarefaRepository {
         log.info("[finaliza] TarefaInfraRepository - buscaTarefaPorId");
         return tarefaPorId;
     }
+	@Override
+	public Optional<Tarefa> buscaTarefaAtiva() {
+		log.info("[inicia] TarefaInfraRepository - buscaTarefaPorId");
+		Optional<Tarefa> tarefaAtiva = tarefaSpringMongoDBRepository.findByStatusAtivacao(StatusAtivacaoTarefa.ATIVA);
+		log.info("[finaliza] TarefaInfraRepository - buscaTarefaPorId");
+		return tarefaAtiva;
+	}
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaInfraRepository.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaInfraRepository.java
@@ -2,14 +2,16 @@ package dev.wakandaacademy.produdoro.tarefa.infra;
 
 import dev.wakandaacademy.produdoro.handler.APIException;
 import dev.wakandaacademy.produdoro.tarefa.application.repository.TarefaRepository;
-import dev.wakandaacademy.produdoro.tarefa.domain.StatusAtivacaoTarefa;
 import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,6 +20,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class TarefaInfraRepository implements TarefaRepository {
     private final TarefaSpringMongoDBRepository tarefaSpringMongoDBRepository;
+	private final MongoTemplate mongoTemplate;
 
     @Override
     public Tarefa salva(Tarefa tarefa) {
@@ -38,10 +41,11 @@ public class TarefaInfraRepository implements TarefaRepository {
         return tarefaPorId;
     }
 	@Override
-	public Optional<Tarefa> buscaTarefaAtiva() {
-		log.info("[inicia] TarefaInfraRepository - buscaTarefaPorId");
-		Optional<Tarefa> tarefaAtiva = tarefaSpringMongoDBRepository.findByStatusAtivacao(StatusAtivacaoTarefa.ATIVA);
-		log.info("[finaliza] TarefaInfraRepository - buscaTarefaPorId");
-		return tarefaAtiva;
+	public void desativaTarefaAtiva(UUID idUsuario) {
+		log.info("[inicia] TarefaInfraRepository - desativaTarefaAtiva");
+		Query query = new Query(Criteria.where("statusAtivacao").is("ATIVA").and("idUsuario").is(idUsuario));
+		Update update = new Update().set("statusAtivacao", "INATIVA");
+		mongoTemplate.updateMulti(query, update, Tarefa.class);
+		log.info("[finaliza] TarefaInfraRepository - desativaTarefaAtiva");
 	}
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaSpringMongoDBRepository.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaSpringMongoDBRepository.java
@@ -1,5 +1,6 @@
 package dev.wakandaacademy.produdoro.tarefa.infra;
 
+import dev.wakandaacademy.produdoro.tarefa.domain.StatusAtivacaoTarefa;
 import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
@@ -8,4 +9,5 @@ import java.util.UUID;
 
 public interface TarefaSpringMongoDBRepository extends MongoRepository<Tarefa, UUID> {
     Optional<Tarefa> findByIdTarefa(UUID idTarefa);
+	Optional<Tarefa> findByStatusAtivacao(StatusAtivacaoTarefa ativa);
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaSpringMongoDBRepository.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaSpringMongoDBRepository.java
@@ -1,6 +1,5 @@
 package dev.wakandaacademy.produdoro.tarefa.infra;
 
-import dev.wakandaacademy.produdoro.tarefa.domain.StatusAtivacaoTarefa;
 import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.Optional;
@@ -8,5 +7,4 @@ import java.util.UUID;
 
 public interface TarefaSpringMongoDBRepository extends MongoRepository<Tarefa, UUID> {
     Optional<Tarefa> findByIdTarefa(UUID idTarefa);
-	Optional<Tarefa> findAllByStatusAtivacaoAndIdUsuario(StatusAtivacaoTarefa ativa, UUID usuario);
 }

--- a/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaSpringMongoDBRepository.java
+++ b/src/main/java/dev/wakandaacademy/produdoro/tarefa/infra/TarefaSpringMongoDBRepository.java
@@ -3,11 +3,10 @@ package dev.wakandaacademy.produdoro.tarefa.infra;
 import dev.wakandaacademy.produdoro.tarefa.domain.StatusAtivacaoTarefa;
 import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
 import org.springframework.data.mongodb.repository.MongoRepository;
-
 import java.util.Optional;
 import java.util.UUID;
 
 public interface TarefaSpringMongoDBRepository extends MongoRepository<Tarefa, UUID> {
     Optional<Tarefa> findByIdTarefa(UUID idTarefa);
-	Optional<Tarefa> findByStatusAtivacao(StatusAtivacaoTarefa ativa);
+	Optional<Tarefa> findAllByStatusAtivacaoAndIdUsuario(StatusAtivacaoTarefa ativa, UUID usuario);
 }

--- a/src/test/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationServiceTest.java
+++ b/src/test/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationServiceTest.java
@@ -2,6 +2,7 @@ package dev.wakandaacademy.produdoro.tarefa.application.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -18,8 +19,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 import dev.wakandaacademy.produdoro.DataHelper;
+import dev.wakandaacademy.produdoro.handler.APIException;
 import dev.wakandaacademy.produdoro.tarefa.application.api.TarefaIdResponse;
 import dev.wakandaacademy.produdoro.tarefa.application.api.TarefaRequest;
 import dev.wakandaacademy.produdoro.tarefa.application.repository.TarefaRepository;
@@ -61,7 +64,7 @@ class TarefaApplicationServiceTest {
     }
     
     @Test
-    @DisplayName("Ativa tarefa - teste")
+    @DisplayName("Ativa tarefa - deve ativar tarefa")
     void ativaTarefaDeveAtivarTarefa() {
     	UUID idTarefa = DataHelper.createTarefa().getIdTarefa();
     	UUID idUsuario = DataHelper.createUsuario().getIdUsuario();
@@ -75,4 +78,16 @@ class TarefaApplicationServiceTest {
     	verify(tarefaRepository, times(1)).desativaTarefaAtiva(idUsuario);
     	assertEquals(StatusAtivacaoTarefa.ATIVA, tarefa.getStatusAtivacao());   	
     }
+    @Test
+    @DisplayName("Ativa tarefa com id invalido - deve retornar exception")
+    void ativaTarefaDeveRetornarErro() {
+    	UUID idTarefaInvalido = UUID.randomUUID();
+    	String email = "email@gmail.com";
+    	when(tarefaRepository.buscaTarefaPorId(idTarefaInvalido)).thenReturn(Optional.empty());
+    	APIException ex = assertThrows(APIException.class,() -> {
+    		tarefaApplicationService.ativaTarefa(email, idTarefaInvalido);
+    		});
+    	assertEquals(HttpStatus.NOT_FOUND, ex.getStatusException());   	
+    }
+
 }

--- a/src/test/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationServiceTest.java
+++ b/src/test/java/dev/wakandaacademy/produdoro/tarefa/application/service/TarefaApplicationServiceTest.java
@@ -1,25 +1,32 @@
 package dev.wakandaacademy.produdoro.tarefa.application.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import dev.wakandaacademy.produdoro.DataHelper;
 import dev.wakandaacademy.produdoro.tarefa.application.api.TarefaIdResponse;
 import dev.wakandaacademy.produdoro.tarefa.application.api.TarefaRequest;
 import dev.wakandaacademy.produdoro.tarefa.application.repository.TarefaRepository;
+import dev.wakandaacademy.produdoro.tarefa.domain.StatusAtivacaoTarefa;
 import dev.wakandaacademy.produdoro.tarefa.domain.Tarefa;
+import dev.wakandaacademy.produdoro.usuario.application.repository.UsuarioRepository;
+import dev.wakandaacademy.produdoro.usuario.domain.Usuario;
 
 @ExtendWith(MockitoExtension.class)
 class TarefaApplicationServiceTest {
@@ -31,6 +38,8 @@ class TarefaApplicationServiceTest {
     //	@MockBean
     @Mock
     TarefaRepository tarefaRepository;
+    @Mock
+    UsuarioRepository usuarioRepository;
 
     @Test
     void deveRetornarIdTarefaNovaCriada() {
@@ -49,5 +58,21 @@ class TarefaApplicationServiceTest {
     public TarefaRequest getTarefaRequest() {
         TarefaRequest request = new TarefaRequest("tarefa 1", UUID.randomUUID(), null, null, 0);
         return request;
+    }
+    
+    @Test
+    @DisplayName("Ativa tarefa - teste")
+    void ativaTarefaDeveAtivarTarefa() {
+    	UUID idTarefa = DataHelper.createTarefa().getIdTarefa();
+    	UUID idUsuario = DataHelper.createUsuario().getIdUsuario();
+    	Tarefa tarefa = DataHelper.createTarefa();
+    	Usuario usuario = DataHelper.createUsuario();
+    	String email = "email@gmail.com";
+    	when(usuarioRepository.buscaUsuarioPorEmail(email)).thenReturn(usuario);
+    	when(tarefaRepository.buscaTarefaPorId(idTarefa)).thenReturn(Optional.of(tarefa));
+    	tarefaApplicationService.ativaTarefa(email, idTarefa);
+    	verify(tarefaRepository, times(1)).buscaTarefaPorId(idTarefa);
+    	verify(tarefaRepository, times(1)).desativaTarefaAtiva(idUsuario);
+    	assertEquals(StatusAtivacaoTarefa.ATIVA, tarefa.getStatusAtivacao());   	
     }
 }


### PR DESCRIPTION
## Funcionalidade: Usuário define tarefa como ativas

Este PR implementa a funcionalidade que permite aos usuários do sistema ativar uma tarefa, garantindo que apenas uma tarefa possa estar ativa por vez. Essa funcionalidade é essencial e garante que o usuário tenha controle sobre suas tarefas ativas.

### **Regras Implementadas**

1. Uma tarefa precisa estar previamente adicionada ao sistema para ser ativada.
2. O sistema deve retornar um erro caso o usuário tente ativar uma tarefa que já está ativa.
3. Apenas uma tarefa pode estar ativa de cada vez.
4. O usuário que está logado deve ser o proprietário da tarefa que está tentando ativar.
5. O token de autenticação deve corresponder ao usuário que é o dono da tarefa.

### **Cenários de Teste**
Adicionei testes unitários para verificar o comportamento da nova funcionalidade em diferentes cenários:

Cenário 1 - Tarefa ativada com sucesso.
Cenário 2 - Tarefa não pode ser ativada com id inválido.